### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/1password_firewall_rules_changed.yml
+++ b/rules/1password_firewall_rules_changed.yml
@@ -2,7 +2,6 @@
 name: 1Password Firewall Rules Changed
 description: |-
   Detect when changes have been made to the firewall rules in 1Password.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_group_privilege_escalation.yml
+++ b/rules/1password_group_privilege_escalation.yml
@@ -3,7 +3,6 @@ name: 1Password Group Privilege Escalation
 description: |-
   Detect when an actor joins a group or assigns themselves a role within a group,
   which may indicate insider threat activity or privilege escalation attempts.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_manual_account_creation.yml
+++ b/rules/1password_manual_account_creation.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when a new account is created manually within 1Password.
   This should only be used when a 1Password integration via a SCIM Bridge
   has been implemented.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_mfa_disabled_for_all_users.yml
+++ b/rules/1password_mfa_disabled_for_all_users.yml
@@ -2,7 +2,6 @@
 name: 1Password MFA Disabled for All Users
 description: |-
   Detect when the MFA factor or type for all user accounts is disabled in 1Password.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_new_service_account_integration.yml
+++ b/rules/1password_new_service_account_integration.yml
@@ -2,7 +2,6 @@
 name: 1Password New Service Account Integration
 description: |-
   Detect when a new service account integration has been created in 1Password.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_service_account_token_adjustment.yml
+++ b/rules/1password_service_account_token_adjustment.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when a service account integration token has been created, renamed,
   verified, or revoked in 1Password. This can indicate an attacker attempting
   to use a non-user identity to compromise a 1Password tenant.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_sso_configuration_changed.yml
+++ b/rules/1password_sso_configuration_changed.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when changes have been made to the SSO configuration in 1Password.
   This can indicate potential persistence or unauthorized changes to
   authentication controls.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_unusual_client.yml
+++ b/rules/1password_unusual_client.yml
@@ -8,7 +8,6 @@ description: |-
   * 1Password for Web/Mac/Windows/Linux/iOS/Android
   * 1Password Browser Extension
   * 1Password SCIM Bridge
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_user_mfa_settings_changed.yml
+++ b/rules/1password_user_mfa_settings_changed.yml
@@ -3,7 +3,6 @@ name: 1Password User MFA Settings Changed
 description: |-
   Detect when a user creates, updates, or disables user account MFA settings
   in 1Password.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password

--- a/rules/1password_vault_privilege_escalation.yml
+++ b/rules/1password_vault_privilege_escalation.yml
@@ -3,7 +3,6 @@ name: 1Password Vault Privilege Escalation
 description: |-
   Detect when an actor grants or updates their own permissions within a vault,
   which may indicate insider threat activity or privilege escalation attempts.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:1password


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.