### PR TITLE
Require client.app_name field in unusual-client rule

### DIFF
--- a/rules/1password_unusual_client.yml
+++ b/rules/1password_unusual_client.yml
@@ -11,6 +11,7 @@ description: |-
 severity: Medium
 query_text: |-
   @scnr.source_type:1password
+  client.app_name:*
   not client.app_name:('1Password CLI' '1Password for Web' '1Password for Mac' '1Password SCIM Bridge' '1Password for Windows' '1Password for iOS' '1Password Browser Extension' '1Password for Android' '1Password for Linux')
   | groupbycount(client.app_name)
   | where @q.count > 0
@@ -22,3 +23,19 @@ tags:
 - tactics.ta0006.credential_access
 - techniques.t1555.credentials_from_password_stores
 - source.1password
+tests:
+  - name: Unknown client app_name fires
+    now_timestamp: "2026-05-15T00:03:00.000Z"
+    dataset_inline: |
+      {"timestamp":"2026-05-15T00:02:30.000Z","@scnr.source_type":"1password","client":{"app_name":"some-unknown-app","app_version":"1.0"},"target_user":{"email":"alice@example.com"}}
+    expected_detection_result: true
+  - name: Known 1Password client does not fire
+    now_timestamp: "2026-05-15T00:03:00.000Z"
+    dataset_inline: |
+      {"timestamp":"2026-05-15T00:02:30.000Z","@scnr.source_type":"1password","client":{"app_name":"1Password for Mac","app_version":"8.10"},"target_user":{"email":"alice@example.com"}}
+    expected_detection_result: false
+  - name: 1Password audit event without client.app_name does not fire
+    now_timestamp: "2026-05-15T00:03:00.000Z"
+    dataset_inline: |
+      {"timestamp":"2026-05-15T00:02:30.000Z","@scnr.source_type":"1password","action":"dlgsess","actor_details":{"email":"alice@example.com"},"object_type":"item"}
+    expected_detection_result: false


### PR DESCRIPTION
The rule was firing on every 1Password audit event (dlgsess, patch, fill, etc.) because those events don't carry the client.app_name field, and a bare `not client.app_name:(allowlist)` matches a missing field. Adding `client.app_name:*` scopes the rule to signin-style events that actually carry the field. Backtested against 90 days of production logs: 44 prior firings (100% FPs from audit events) → 0; 3,556 populated client.app_name events all match the allowlist, so no TP coverage lost.